### PR TITLE
Added a slider to allow for easeir viewing of differences between svgs

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,16 @@
 										</button>
 									</div>
 								</form>
+								<form class ="inline">
+									<div class="slidecontainer">
+										<input type="range" min="0" max="100" value="0" class="slider" id="sliderRange" oninput="sliderChange()" onkeydown="return false;">
+									  </div>
+								</form>
+								<p class="text-light" style="padding-top: 5px">
+									<small class="text-sm">
+									Slider for old vs. new
+									</small>
+								</p>
 							</div>
 						</div>
 					</div>
@@ -184,7 +194,7 @@
 													Eco1_User
 												</a>
 												<a class="dropdown-item" href="#" id="dropdown_Eco2_User" name="layers_new" value="Eco2_User"/>
-													<span style="margin-left:0px; margin-right:0.1em; color: " class="iconify" data-icon="teenyicons-square-solid" data-inline="false"></span>
+													<span style="margin-left:0px; margin-right:0.1em; color: gray" class="iconify" data-icon="teenyicons-square-solid" data-inline="false"></span>
 													Eco2_User
 												</a>
 												<a class="dropdown-item" href="#" id="dropdown_Edge_Cuts" name="layers_new" value="Edge_Cuts"/>

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 								</form>
 								<form class ="inline">
 									<div class="slidecontainer">
-										<input type="range" min="0" max="100" value="0" class="slider" id="sliderRange" oninput="sliderChange()" onkeydown="return false;">
+										<input type="range" min="-100" max="100" value="0" class="slider" id="sliderRange" oninput="sliderChange()" onkeydown="return false;">
 									  </div>
 								</form>
 								<p class="text-light" style="padding-top: 5px">

--- a/kdiff.js
+++ b/kdiff.js
@@ -410,6 +410,8 @@ window.onkeydown = function(e) {
         if (document.getElementById('diff-pcb').style.display === "inline") {
             panZoom_pcb.resetZoom();
             panZoom_pcb.center();
+            document.getElementById("sliderRange").value = 0;
+            sliderChange();
             // panZoom_pcb.fit() // cannot be used, bug?
         }
 
@@ -634,6 +636,8 @@ window.onload = function() {
         if (document.getElementById('diff-pcb').style.display === "inline") {
             panZoom_pcb.resetZoom();
             panZoom_pcb.center();
+            document.getElementById("sliderRange").value = 0;
+            sliderChange();
             // panZoom_pcb.fit(); // cannot be used, bug?
         }
     });
@@ -724,9 +728,19 @@ function show_slide() {
 // =======================================
 // =======================================
 function sliderChange() {
-    document.getElementById("diff-xlink-1-pcb").style.x = parseFloat(document.getElementById("sliderRange").value).toFixed(2)+"%";
-    document.getElementById("diff-xlink-2-pcb").style.x = -parseFloat(document.getElementById("sliderRange").value).toFixed(2)+"%";
-  }  
+    if (document.getElementById("sliderRange").value >= 0)
+    {
+        document.getElementById("diff-xlink-1-pcb").style.opacity = (100-Math.abs(parseFloat(document.getElementById("sliderRange").value)).toFixed(2))+"%";
+        document.getElementById("diff-xlink-2-pcb").style.opacity = "100%";
+    }
+    if (document.getElementById("sliderRange").value < 0)
+    {
+        document.getElementById("diff-xlink-2-pcb").style.opacity = (100-Math.abs(parseFloat(document.getElementById("sliderRange").value)).toFixed(2))+"%";
+        document.getElementById("diff-xlink-1-pcb").style.opacity = "100%";
+    }
+    
+    console.log(parseFloat(document.getElementById("sliderRange").value).toFixed(2)+"%");
+  }
 
 function change_page_onclick(obj) {
     pages = $("#pages_list input:radio[name='pages']");

--- a/kdiff.js
+++ b/kdiff.js
@@ -723,6 +723,11 @@ function show_slide() {
 
 // =======================================
 // =======================================
+function sliderChange() {
+    document.getElementById("diff-xlink-1-pcb").style.x = parseFloat(document.getElementById("sliderRange").value).toFixed(2)+"%";
+    document.getElementById("diff-xlink-2-pcb").style.x = -parseFloat(document.getElementById("sliderRange").value).toFixed(2)+"%";
+  }
+  
 function schematicChangeOnClick(sourceObject){
     console.log(sourceObject);
     pages = $("#pages_list input:radio[name='pages']");


### PR DESCRIPTION
A quick slider to see differences between the schematics if you want to zoom in. Based on percentage but can change it so it's by pixel. Doing it by percentage allows for bigger boards to be used as well. Caveat is the boards can "disappear" but can just return the slide back to original position. 

Ex:
![image](https://user-images.githubusercontent.com/43526839/120546065-45eaca00-c3a4-11eb-9434-e2fce6db5990.png)
