### PR TITLE
fix: Load correct KiCad project path by avoiding attempt to escape path

### DIFF
--- a/webserver.py
+++ b/webserver.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     kicad_project_path = os.path.dirname(os.path.realpath(args.kicad_pcb))
     board_file = os.path.basename(os.path.realpath(args.kicad_pcb))
 
-    prjctPath, kicad_project = get_kicad_project_path(escape_string(kicad_project_path))
+    prjctPath, kicad_project = get_kicad_project_path(kicad_project_path)
 
     if not args.webserver_disable:
 


### PR DESCRIPTION
I had issues opening a KiCad project in a path that contained spaces. It 
looks like `kicad_project_path` is considered to be an exact path, and 
so escaping it can place backslashes into the string that break the 
path.

I'm sure there was probably an edge case that the escaping was intended to cover. I'm submitting this PR as a starting point towards fixing the issue!