### PR TITLE
Added missing MacOS M1 dependencies

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -203,6 +203,7 @@ macos_install_brew_modules()
 	brew install imagemagick
 	brew install cliclick
 	brew install rename
+	brew install dos2unix
 }
 
 # =============================================
@@ -262,6 +263,7 @@ install_opam_modules()
 	opam install -y base64
 	opam install -y sha
 	opam install -y tyxml
+	opam install -y git
 	opam install -y git-unix
 }
 


### PR DESCRIPTION
Fixes issue #130
This should allow future users installing on MacOS Apple silicone to install the script without the 2 dependency errors I saw while installing and running